### PR TITLE
Run data loader in main thread

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -28,7 +28,7 @@ else:
     device = 'cpu'
 
 # args for dataloader and display.
-opts.num_threads    = 1
+opts.num_threads    = 0
 opts.batch_size     = 1
 opts.serial_batches = True
 opts.display_id     = -1


### PR DESCRIPTION
This fixes the runtime error below, when running `inference.py`

```
RuntimeError: 
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```